### PR TITLE
fixing iss #112

### DIFF
--- a/commands/read_write/niak_grab_fmri_preprocess.m
+++ b/commands/read_write/niak_grab_fmri_preprocess.m
@@ -84,12 +84,8 @@
 %           'scores' : FILES is ready to feed into NIAK_PIPELINE_SCORES
 %
 %   TEMPLATE
-%       (string, default 'cambridge') specifies the template to be used if 
-%       OPT.TYPE_FILES is set to 'scores'.
-%       
-%       'cambridge' : the down-sampled cambridge template with 7 networks
-%
-%       'aal' : the aal template
+%       (string, default '') specifies full path for the template to be used. this 
+%       option is active only if  OPT.TYPE_FILES is set to 'scores'
 %
 % _________________________________________________________________________
 % OUTPUTS:
@@ -173,7 +169,7 @@ end
 
 %% Default options
 list_fields   = { 'filter' , 'flag_areas' , 'min_nb_vol' , 'max_translation' , 'max_rotation' , 'min_xcorr_func' , 'min_xcorr_anat' , 'exclude_subject' , 'include_subject' , 'type_files' , 'template'  };
-list_defaults = { struct   , true         , 100          , Inf               , Inf            , 0.5              , 0.5              , {}                , {}                , 'rest'       , 'cambridge' };
+list_defaults = { struct   , true         , 100          , Inf               , Inf            , 0.5              , 0.5              , {}                , {}                , 'rest'       , '' };
 if nargin > 1
     opt = psom_struct_defaults(opt,list_fields,list_defaults);
 else
@@ -345,9 +341,11 @@ if ~strcmp(opt.type_files,'glm_connectome')
 end
 
 if strcmp(opt.type_files, 'scores')
-    files.part = dir([path_data 'anat' filesep sprintf('template_%s*.*', opt.template)]);
-    if isempty(files.part)
-        error('Could not find the %s template', opt.template)
-    end
-    files.part = [path_data 'anat' filesep files.part(1).name];
+   if isempty(opt.template)
+      warning('Template file is empty')
+   elseif exist(opt.template)
+      files.part = opt.template;
+   else 
+      error('Could not find the template file %s', opt.template)
+   end
 end


### PR DESCRIPTION
when grabbing preprocess for scores pipeline, a template partition prior is automatically set to cambridge. I've changed this behavior by allowing a manual selection of template  in `opt.template`.