### PR TITLE
Iss169

### DIFF
--- a/bricks/fmri_preprocess/niak_brick_slice_timing.m
+++ b/bricks/fmri_preprocess/niak_brick_slice_timing.m
@@ -216,9 +216,9 @@ function [files_in,files_out,opt] = niak_brick_slice_timing(files_in,files_out,o
 % _________________________________________________________________________
 % Copyright (c) Pierre Bellec, Sebastien Lavoie-Courchesne
 % Montreal Neurological Institute, 2008-2010
-% Centre de recherche de l'institut de gériatrie de Montréal, 
+% Centre de recherche de l'institut de geriatrie de Montreal, 
 % Department of Computer Science and Operations Research
-% University of Montreal, Québec, Canada, 2010-2014
+% University of Montreal, Qubec, Canada, 2010-2014
 % Maintainer : pierre.bellec@criugm.qc.ca
 % See licensing information in the code.
 % Keywords : medical imaging, slice timing, fMRI

--- a/commands/read_write/niak_mkdir.m
+++ b/commands/read_write/niak_mkdir.m
@@ -5,7 +5,7 @@ function [success,message,messageid] = niak_mkdir(path_name)
 % existing directory. 
 %
 % SYNTAX:
-% [SUCCESS,MESSAGE,MESSAGEID] = MKDIR(PATH_NAME)
+% [SUCCESS,MESSAGE,MESSAGEID] = NIAK_MKDIR(PATH_NAME)
 %
 % _________________________________________________________________________
 % INPUTS:

--- a/commands/read_write/niak_read_data_minc.m
+++ b/commands/read_write/niak_read_data_minc.m
@@ -1,0 +1,84 @@
+function vol = niak_read_data_minc(hdr,precision_data)
+% Read data from a MINC file (.MNC or .MNC.GZ).
+%
+% SYNTAX: VOL = NIAK_READ_DATA_MINC(HDR)
+%
+% HDR (structure) a description of the data, generated from NIAK_READ_VOL.
+% VOL (array) volume data from the minc file used to read HDR. 
+%
+% SEE ALSO: NIAK_READ_HDR_MINC, NIAK_WRITE_MINC, NIAK_READ_VOL, 
+%     NIAK_WRITE_VOL, NIAK_READ_MINC
+%
+% COMMENTS: the data is forced to float precision.
+%
+% EXAMPLE:
+%   % start by reading the header of an existing file
+%   hdr = niak_read_vol('my_file.mnc');
+%   % latter read the actual volume data 
+%   vol = niak_read_data_minc(hdr);
+%
+% See license in the code. 
+ 
+% Copyright (c) Pierre Bellec, 2008-2016.
+% Montreal Neurological Institute, 2008-2010
+% Centre de recherche de l'institut de geriatrie de Montreal, 
+% Department of Computer Science and Operations Research
+% University of Montreal, Qubec, Canada, 2010-2016
+% Maintainer: pierre.bellec@criugm.qc.ca
+% See licensing information in the code.
+% Keywords: medical imaging, I/O, reader, nifti
+%
+% Permission is hereby granted, free of charge, to any person obtaining a copy
+% of this software and associated documentation files (the "Software"), to deal
+% in the Software without restriction, including without limitation the rights
+% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+% copies of the Software, and to permit persons to whom the Software is
+% furnished to do so, subject to the following conditions:
+%
+% The above copyright notice and this permission notice shall be included in
+% all copies or substantial portions of the Software.
+%
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+% THE SOFTWARE.
+
+if nargin < 2
+    precision_data = 'float';
+end
+
+%% Unzip file if necessary
+file_name = hdr.info.file_parent;
+[file_tmp_mnc,flag_zip] = niak_unzip(file_name);
+[path_tmp,name_tmp,ext_tmp] = fileparts(file_tmp_mnc);
+
+%% Generating a name for a temporary file
+file_tmp = niak_file_tmp([name_tmp '.dat']);
+
+%% extracting the data in float precision in the temporary file
+[flag,str_info] = system(cat(2,'minctoraw -',precision_data,' -normalize ',file_name,' > ',file_tmp));
+
+if flag>0
+    error(sprintf('niak:read : %s',str_info))
+end
+
+%% reading information
+hf = fopen(file_tmp,'r');
+try
+    vol = fread(hf,prod(hdr.info.dimensions),['*' precision_data]);
+catch
+    vol = fread(hf,prod(hdr.info.dimensions),precision_data);
+end
+
+%% Removing temporary stuff
+fclose(hf);
+if flag_zip
+  delete(file_tmp_mnc);
+end
+delete(file_tmp);
+
+%% Shapping vol as 3D+t array
+vol = reshape(vol,hdr.info.dimensions);

--- a/commands/read_write/niak_read_data_minc.m
+++ b/commands/read_write/niak_read_data_minc.m
@@ -4,6 +4,8 @@ function vol = niak_read_data_minc(hdr,precision_data)
 % SYNTAX: VOL = NIAK_READ_DATA_MINC(HDR)
 %
 % HDR (structure) a description of the data, generated from NIAK_READ_VOL.
+%   The name of the file that will be used to extract data is stored in 
+%   HDR.INFO.FILE_PARENT.
 % VOL (array) volume data from the minc file used to read HDR. 
 %
 % SEE ALSO: NIAK_READ_HDR_MINC, NIAK_WRITE_MINC, NIAK_READ_VOL, 
@@ -16,6 +18,9 @@ function vol = niak_read_data_minc(hdr,precision_data)
 %   hdr = niak_read_vol('my_file.mnc');
 %   % latter read the actual volume data 
 %   vol = niak_read_data_minc(hdr);
+%   % read a different file, with identical header structure
+%   hdr.info.file_parent = 'my_file2.mnc';
+%   vol2 = niak_read_data_minc(hdr);
 %
 % See license in the code. 
  

--- a/commands/read_write/niak_read_data_nifti.m
+++ b/commands/read_write/niak_read_data_nifti.m
@@ -4,6 +4,8 @@ function vol = niak_read_data_nifti(hdr)
 % SYNTAX: VOL = NIAK_READ_DATA_NIFTI(HDR)
 %
 % HDR (structure) a description of the data, generated from NIAK_READ_VOL.
+%   The name of the file that will be used to extract data is stored in 
+%   HDR.INFO.FILE_PARENT.
 % VOL (array) volume data from the nifti file used to read HDR. 
 %
 % SEE ALSO: NIAK_READ_HDR_NIFTI, NIAK_WRITE_NIFTI, NIAK_READ_VOL, 
@@ -16,6 +18,9 @@ function vol = niak_read_data_nifti(hdr)
 %   hdr = niak_read_vol('my_file.nii.gz');
 %   % latter read the actual volume data 
 %   vol = niak_read_data_nifti(hdr);
+%   % read a different file, with identical header structure
+%   hdr.info.file_parent = 'my_file2.nii.gz';
+%   vol2 = niak_read_data_nifti(hdr);
 %
 % See license in the code. 
  

--- a/commands/read_write/niak_read_data_nifti.m
+++ b/commands/read_write/niak_read_data_nifti.m
@@ -1,0 +1,127 @@
+function vol = niak_read_data_nifti(hdr)
+% Read data from a NIFTI file (.NII or .IMG).
+%
+% SYNTAX: VOL = NIAK_READ_DATA_NIFTI(HDR)
+%
+% HDR (structure) a description of the data, generated from NIAK_READ_VOL.
+% VOL (array) volume data from the nifti file used to read HDR. 
+%
+% SEE ALSO: NIAK_READ_HDR_NIFTI, NIAK_WRITE_NIFTI, NIAK_READ_VOL, 
+%     NIAK_WRITE_VOL, NIAK_READ_NIFI
+%
+% COMMENTS: the data is forced to single precision.
+%
+% EXAMPLE:
+%   % start by reading the header of an existing file
+%   hdr = niak_read_vol('my_file.nii.gz');
+%   % latter read the actual volume data 
+%   vol = niak_read_data_nifti(hdr);
+%
+% See license in the code. 
+ 
+% Copyright (c) Pierre Bellec, 2008-2016.
+% Montreal Neurological Institute, 2008-2010
+% Centre de recherche de l'institut de geriatrie de Montreal, 
+% Department of Computer Science and Operations Research
+% University of Montreal, Qubec, Canada, 2010-2016
+% Maintainer: pierre.bellec@criugm.qc.ca
+% See licensing information in the code.
+% Keywords: medical imaging, I/O, reader, nifti
+%
+% Permission is hereby granted, free of charge, to any person obtaining a copy
+% of this software and associated documentation files (the "Software"), to deal
+% in the Software without restriction, including without limitation the rights
+% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+% copies of the Software, and to permit persons to whom the Software is
+% furnished to do so, subject to the following conditions:
+%
+% The above copyright notice and this permission notice shall be included in
+% all copies or substantial portions of the Software.
+%
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+% THE SOFTWARE.
+
+%% Unzip file if necessary
+file_name = hdr.info.file_parent;
+[file_tmp,flag_zip] = niak_unzip(file_name);
+    
+%% Opening the data file
+fid = fopen(file_tmp,'r',hdr.info.machine);
+
+if fid < 0,
+    msg = sprintf('Cannot open file %s.',file_name);
+    error(msg);
+end
+
+if hdr.details.dim(5) < 1
+    hdr.details.dim(5) = 1;
+end
+
+%  move pointer to the start of image block
+%
+switch hdr.type
+    case {'vol', 'analyze'}
+        fseek(fid, 0, 'bof');
+    case 'nii'
+        fseek(fid, hdr.details.vox_offset, 'bof');
+end
+
+
+%  For each frame, precision of value will be read
+%  in vol_siz times, where vol_siz is only the
+%  dimension size of an image, not the byte storage
+%  size of an image.
+vol_siz = prod(hdr.details.dim(2:5));
+
+%%  For complex float32 or complex float64, voxel values
+%%  include [real, imag]
+if (hdr.details.datatype == 32) || (hdr.details.datatype == 1792)
+    vol_siz = vol_siz * 2;
+end
+
+%% MPH: For RGB24, voxel values include 3 separate color planes
+if (hdr.details.datatype == 128) || (hdr.details.datatype == 511)
+    vol_siz = vol_siz * 3;
+end
+
+vol = fread(fid, vol_siz, sprintf('*%s',hdr.info.precision));
+
+%%  For complex float32 or complex float64, voxel values
+%%  include [real, imag]
+if (hdr.details.datatype == 32) || (hdr.details.datatype == 1792)
+    vol = reshape(vol, [2, length(vol)/2]);
+    vol = complex(vol(1,:)', vol(2,:)');
+end
+fclose(fid);
+
+%% Reshape the volume to correct dimensions
+vol_idx = 1:hdr.details.dim(5);
+
+if (hdr.details.datatype == 128) && (hdr.details.bitpix == 24)
+    vol = squeeze(reshape(vol, [3 hdr.details.dim(2:4) length(vol_idx)]));
+    vol = permute(vol, [2 3 4 1 5]);
+elseif (hdr.details.datatype == 511) && (hdr.details.bitpix == 96)
+    vol = single(vol);
+    vol = (vol - min(vol))/(max(vol) - min(vol));
+    vol = squeeze(reshape(vol, [3 hdr.details.dim(2:4) length(vol_idx)]));
+    vol = permute(vol, [2 3 4 1 5]);
+else
+    vol = squeeze(reshape(vol, [hdr.details.dim(2:4) length(vol_idx)]));
+end
+
+if ((hdr.details.scl_slope~=0)&&(hdr.details.scl_slope~=1))||(hdr.details.scl_inter~=0)
+    vol = hdr.details.scl_slope * single(vol) + hdr.details.scl_inter;
+end  
+
+%% Hack: force to single precision
+vol = single(vol);
+
+%% remove temporary file
+if flag_zip
+    delete(file_tmp);
+end    

--- a/commands/read_write/niak_read_hdr_nifti.m
+++ b/commands/read_write/niak_read_hdr_nifti.m
@@ -4,47 +4,32 @@ function hdr = niak_read_hdr_nifti(file_name)
 % affine transformation information will be included.
 % http://nifti.nimh.nih.gov/nifti-1
 % 
-% SYNTAX:
-% HDR = NIAK_READ_HDR_NIFTI(FILE_NAME)
+% SYNTAX: HDR = NIAK_READ_HDR_NIFTI(FILE_NAME)
 %
-% _________________________________________________________________________
-% INPUT:
+% FILE_NAME (string) name of a single 3D+t nifti file or a 3D nifti file.
+%   Compressed files (.nii.gz) are not supported.
+% HDR (structure) contain a description of the data. For a list of fields 
+%   common to all data types, see NIAK_READ_VOL.
+% HDR.DETAILS (structure) contains the standard fields of a nifti file. 
+%   See http://nifti.nimh.nih.gov/nifti-1.
 %
-% FILE_NAME     
-%    (string) name of a single 3D+t minc file or a 3D minc file.
+% EXAMPLE:
+%   hdr = niak_read_hdr_nifti('my_vol.nii');
 %
-% _________________________________________________________________________
-% OUTPUT:
-%
-% HDR           
-%    (structure) contain a description of the data. For a list of fields 
-%    common to all data types, see NIAK_READ_VOL.
-%
-%    HDR.DETAILS 
-%        (structure) contains the standard fields of a nifti file. 
-%        See http://nifti.nimh.nih.gov/nifti-1.
-%
-% _________________________________________________________________________
 % SEE ALSO:
+%   NIAK_READ_NIFTI, NIAK_WRITE_NIFTI, NIAK_READ_VOL, NIAK_WRITE_VOL
 %
-% NIAK_READ_NIFTI, NIAK_WRITE_NIFTI, NIAK_READ_VOL, NIAK_WRITE_VOL
-%
-% _________________________________________________________________________
-% COMMENTS:
-%
-% Part of this file is copied and modified under GNU license from
-% MRI_TOOLBOX developed by CNSP in Flinders University, Australia
-%
-% Important parts of this code are copied and modified from a matlab
-% toolbox by Jimmy Shen (pls@rotman-baycrest.on.ca). Unfortunately, this
-% toolbox did not include a copyright notice.
-% http://www.mathworks.com/matlabcentral/fileexchange/loadFile.do?objectId=8797&objectType=file
-%
-% Copyright (c) Pierre Bellec, Montreal Neurological Institute, 2008.
-% Maintainer : pbellec@bic.mni.mcgill.ca
+% See license in the code. 
+ 
+% Copyright (c) Pierre Bellec, Jimmy Shen, 2008-2016.
+% Montreal Neurological Institute, 2008-2010
+% Centre de recherche de l'institut de geriatrie de Montreal, 
+% Department of Computer Science and Operations Research
+% University of Montreal, Qubec, Canada, 2010-2016
+% Maintainer: pierre.bellec@criugm.qc.ca
 % See licensing information in the code.
-% Keywords : medical imaging, I/O, reader, nifti
-
+% Keywords: medical imaging, I/O, reader, nifti
+%
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the "Software"), to deal
 % in the Software without restriction, including without limitation the rights

--- a/commands/read_write/niak_read_minc.m
+++ b/commands/read_write/niak_read_minc.m
@@ -2,44 +2,36 @@ function [hdr,vol] = niak_read_minc(file_name,precision_data)
 % Read 3D or 3D+t data in MINC format.
 % http://www.bic.mni.mcgill.ca/software/minc/
 %
-% SYNTAX:
-% [HDR,VOL] = NIAK_READ_MINC(FILE_NAME)
-% 
-% _________________________________________________________________________
-% INPUT:
+% SYNTAX: [HDR,VOL] = NIAK_READ_MINC(FILE_NAME)
 %
-% FILE_NAME         
-%       (string) a 3D+t or 3D minc file.
+% FILE_NAME (string) a 3D+t or 3D minc file. 
+% VOL (3D+t or 3D array of double) the fMRI or MRI data.
+% HDR (structure) description of the data. See NIAK_READ_VOL 
+%   and NIAK_READ_HDR_MINC for details.
 %
-% _________________________________________________________________________
-% OUTPUT:
+% SEE ALSO: NIAK_READ_HDR_MINC, NIAK_WRITE_MINC, NIAK_READ_VOL, NIAK_WRITE_VOL
 %
-% VOL           
-%       (3D+t or 3D array of double) the fMRI or MRI data.
+% COMMENTS: Use shell commands MINCINFO (for minc1), MINCHEADER and MINCTORAW which 
+%  requires a proper install of minc tools. This function is
+%  creating temporary files. If it does not work, try to change the location 
+%  of temporary files using the GB_NIAK_TMP variable defined in 
+%  the NIAK_GB_VARS function.
 %
-% HDR
-%       a structure containing a description of the data. See NIAK_READ_VOL 
-%       and NIAK_READ_HDR_MINC for details.
+% EXAMPLES: 
+%   To read the header of a file, with the volumetric data
+%     [hdr,vol] = niak_read_minc('my_file.mnc');
 %
-% _________________________________________________________________________
-% SEE ALSO:
-%
-% NIAK_READ_HDR_MINC, NIAK_WRITE_MINC, NIAK_READ_VOL, NIAK_WRITE_VOL
-%
-% _________________________________________________________________________
-% COMMENTS: 
-%
-% Use shell commands MINCINFO (for minc1), MINCHEADER and MINCTORAW which 
-% requires a proper install of minc tools. This function is
-% creating temporary files. If it does not work, try to change the location 
-% of temporary files using the GB_NIAK_TMP variable defined in 
-% the NIAK_GB_VARS function.
-% 
-% Copyright (c) Pierre Bellec, Montreal Neurological Institute, 2008.
-% Maintainer : pbellec@bic.mni.mcgill.ca
+% See license in the code. 
+ 
+% Copyright (c) Pierre Bellec, 2008-2016.
+% Montreal Neurological Institute, 2008-2010
+% Centre de recherche de l'institut de geriatrie de Montreal, 
+% Department of Computer Science and Operations Research
+% University of Montreal, Qubec, Canada, 2010-2016
+% Maintainer: pierre.bellec@criugm.qc.ca
 % See licensing information in the code.
-% Keywords : medical imaging, I/O, reader, minc
-
+% Keywords: medical imaging, I/O, reader, minc
+%
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the "Software"), to deal
 % in the Software without restriction, including without limitation the rights
@@ -62,35 +54,18 @@ if nargin < 2
     precision_data = 'float';
 end
 
+%% Unzip
+[path_f,name_f,ext_f] = fileparts(file_name);
+path_f = niak_full_path(path_f);
+file_name = [path_f,name_f,ext_f];
+[file_tmp,flag_zip] = niak_unzip(file_name);
+
 %% Parsing the header
-hdr = niak_read_hdr_minc(file_name);
-hdr.info.precision = precision_data;
-
-[path_tmp,name_tmp,ext_tmp] = fileparts(file_name);
-
-if nargout == 2
-    %% Generating a name for a temporary file
-    file_tmp = niak_file_tmp([name_tmp '.dat']);
-
-    %% extracting the data in float precision in the temporary file
-    [flag,str_info] = system(cat(2,'minctoraw -',precision_data,' -normalize ',file_name,' > ',file_tmp));
-    
-    if flag>0
-        error(sprintf('niak:read : %s',str_info))
-    end
-    
-    %% reading information
-    hf = fopen(file_tmp,'r');
-    try
-        vol = fread(hf,prod(hdr.info.dimensions),['*' precision_data]);
-    catch
-        vol = fread(hf,prod(hdr.info.dimensions),precision_data);
-    end
-
-    %% Removing temporary stuff
-    fclose(hf);
-    delete(file_tmp);
-
-    %% Shapping vol as 3D+t array
-    vol = reshape(vol,hdr.info.dimensions);
+hdr = niak_read_hdr_minc(file_tmp);
+hdr.info.file_parent = file_name;
+if nargout > 1
+    vol = niak_read_data_minc(hdr);
+end
+if flag_zip
+  delete(file_tmp);
 end

--- a/commands/read_write/niak_read_nifti.m
+++ b/commands/read_write/niak_read_nifti.m
@@ -4,57 +4,37 @@ function [hdr,vol] = niak_read_nifti(file_name)
 % affine transformation information will be included.
 % http://nifti.nimh.nih.gov/nifti-1
 %
-% SYNTAX:
-% [HDR,VOL] = NIAK_READ_NIFTI(FILE_NAME)
+% SYNTAX: [HDR,VOL] = NIAK_READ_NIFTI(FILE_NAME)
 %
-% _________________________________________________________________________
-% INPUT:
-%
-% FILE_NAME         
-%    (string) a 3D+t or 3D minc file.
-%
-% _________________________________________________________________________
-% OUTPUT:
-%
-% VOL           
-%    (3D+t or 3D array of double) the fMRI or MRI data.
-%
-% HDR           
-%    a structure containing a description of the data. See NIAK_READ_VOL 
+% FILE_NAME (string) a 3D+t or 3D minc nifti file.
+% VOL (3D+t or 3D array of double) the fMRI or MRI data.
+% HDR (structure) a description of the data. See NIAK_READ_VOL 
 %    and NIAK_READ_HDR_NIFTI for details.
 %
-% _________________________________________________________________________
-% SEE ALSO:
+% SEE ALSO: NIAK_READ_HDR_NIFTI, NIAK_WRITE_NIFTI, NIAK_READ_VOL, 
+%     NIAK_WRITE_VOL, NIAK_READ_DATA_NIFI
 %
-% NIAK_READ_HDR_NIFTI, NIAK_WRITE_NIFTI, NIAK_READ_VOL, NIAK_WRITE_VOL
-%
-% _________________________________________________________________________
 % COMMENTS:
+%   In case of multiple files data (e.g. .IMG + .HDR, or .IMG + .HDR + .MAT),
+%   specify the name using the .IMG extension only.
 %
-% In case of multiple files data (e.g. .IMG + .HDR, or .IMG + .HDR + .MAT),
-% specify the name using the .IMG extension only.
-%
-% The affine transformation in hdr.info corresponds to the sform, if specified, or 
-% the qform (if sform unspecified and qform is), or simply the pixel dimension 
-% and offset, if neither qform or sform are specified. 
+%   The affine transformation in hdr.info corresponds to the sform, if specified, or 
+%   the qform (if sform unspecified and qform is), or simply the pixel dimension 
+%   and offset, if neither qform or sform are specified. 
 % 
-% Part of this file is copied and modified under GNU license from
-% MRI_TOOLBOX developed by CNSP in Flinders University, Australia
+%   The data is forced to single precision.
 %
-% Important parts of this code are copied and modified from a matlab
-% toolbox by Jimmy Shen (pls@rotman-baycrest.on.ca) who agreed for 
-% redistribution under the MIT license. 
-%
-% Note that the precision of the data is forced to single (32 bits). 
-% 
-% Copyright (c) Pierre Bellec, 
+% See license in the code. 
+ 
+% Copyright (c) Pierre Bellec, Jimmy Shen, 2008-2016.
 % Montreal Neurological Institute, 2008-2010
-% Departement d'informatique et de recherche operationnelle
-% Centre de recherche de l'institut de Geriatrie de Montreal
-% Universite de Montreal, 2011-2015
+% Centre de recherche de l'institut de geriatrie de Montreal, 
+% Department of Computer Science and Operations Research
+% University of Montreal, Qubec, Canada, 2010-2016
+% Maintainer: pierre.bellec@criugm.qc.ca
 % See licensing information in the code.
-% Keywords : medical imaging, I/O, reader, nifti
-
+% Keywords: medical imaging, I/O, reader, nifti
+%
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the "Software"), to deal
 % in the Software without restriction, including without limitation the rights
@@ -73,16 +53,12 @@ function [hdr,vol] = niak_read_nifti(file_name)
 % OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 % THE SOFTWARE.
 
-if nargin < 2
-    precision_data = 'float';
-end
-
 [path_f,name_f,ext_f] = fileparts(file_name);
 if isempty(path_f)
     path_f = '.';
 end
 switch ext_f
-    case '.nii'
+    case {'.nii','.nii.gz'}
         file_header = file_name;
     case '.img'
         file_header = cat(2,path_f,filesep,name_f,'.hdr');
@@ -92,83 +68,7 @@ end
 
 %% Parsing the header
 hdr = niak_read_hdr_nifti(file_header);
-
+hdr.info.file_parent = file_name;
 if nargout > 1
-    %% Opening the data file
-
-    fid = fopen(file_name,'r',hdr.info.machine);
-
-    if fid < 0,
-        msg = sprintf('Cannot open file %s.',file_name);
-        error(msg);
-    end
-
-    if hdr.details.dim(5) < 1
-        hdr.details.dim(5) = 1;
-    end
-
-    %  move pointer to the start of image block
-    %
-    switch hdr.type
-        case {'vol', 'analyze'}
-            fseek(fid, 0, 'bof');
-        case 'nii'
-            fseek(fid, hdr.details.vox_offset, 'bof');
-    end
-
-
-    %  For each frame, precision of value will be read
-    %  in vol_siz times, where vol_siz is only the
-    %  dimension size of an image, not the byte storage
-    %  size of an image.
-    vol_siz = prod(hdr.details.dim(2:5));
-
-    %%  For complex float32 or complex float64, voxel values
-    %%  include [real, imag]
-    if (hdr.details.datatype == 32) || (hdr.details.datatype == 1792)
-        vol_siz = vol_siz * 2;
-    end
-
-    %% MPH: For RGB24, voxel values include 3 separate color planes
-    if (hdr.details.datatype == 128) || (hdr.details.datatype == 511)
-        vol_siz = vol_siz * 3;
-    end
-
-    vol = fread(fid, vol_siz, sprintf('*%s',hdr.info.precision));
-
-    %%  For complex float32 or complex float64, voxel values
-    %%  include [real, imag]
-    if (hdr.details.datatype == 32) || (hdr.details.datatype == 1792)
-        vol = reshape(vol, [2, length(vol)/2]);
-        vol = complex(vol(1,:)', vol(2,:)');
-    end
-
-    fclose(fid);
-
-    %%  Update the global min and max values
-    hdr.details.glmax = max(double(vol(:)));
-    hdr.details.glmin = min(double(vol(:)));
-
-    %% Reshape the volume to correct dimensions
-    vol_idx = 1:hdr.details.dim(5);
-
-    if (hdr.details.datatype == 128) && (hdr.details.bitpix == 24)
-        vol = squeeze(reshape(vol, [3 hdr.details.dim(2:4) length(vol_idx)]));
-        vol = permute(vol, [2 3 4 1 5]);
-    elseif (hdr.details.datatype == 511) && (hdr.details.bitpix == 96)
-        vol = single(vol);
-        vol = (vol - min(vol))/(max(vol) - min(vol));
-        vol = squeeze(reshape(vol, [3 hdr.details.dim(2:4) length(vol_idx)]));
-        vol = permute(vol, [2 3 4 1 5]);
-    else
-        vol = squeeze(reshape(vol, [hdr.details.dim(2:4) length(vol_idx)]));
-    end
-    
-    if ((hdr.details.scl_slope~=0)&&(hdr.details.scl_slope~=1))||(hdr.details.scl_inter~=0)
-        vol = hdr.details.scl_slope * single(vol) + hdr.details.scl_inter;
-        hdr.details.scl_slope = 1;
-        hdr.details.scl_inter = 0;
-    end  
-    vol = single(vol);
-    hdr.info.precision = 'float';
+    vol = niak_read_data_nifti(hdr);
 end

--- a/commands/read_write/niak_read_nifti.m
+++ b/commands/read_write/niak_read_nifti.m
@@ -52,23 +52,15 @@ function [hdr,vol] = niak_read_nifti(file_name)
 % LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 % OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 % THE SOFTWARE.
-
 [path_f,name_f,ext_f] = fileparts(file_name);
-if isempty(path_f)
-    path_f = '.';
-end
-switch ext_f
-    case {'.nii','.nii.gz'}
-        file_header = file_name;
-    case '.img'
-        file_header = cat(2,path_f,filesep,name_f,'.hdr');
-    otherwise
-        error('niak:read: Unkown extension type : %s. I am expecting ''.nii'' or ''.img''',ext_f)
-end
-
-%% Parsing the header
-hdr = niak_read_hdr_nifti(file_header);
+path_f = niak_full_path(path_f);
+file_name = [path_f,name_f,ext_f];
+[file_tmp,flag_zip] = niak_unzip(file_name);
+hdr = niak_read_hdr_nifti(file_tmp);
 hdr.info.file_parent = file_name;
 if nargout > 1
-    vol = niak_read_data_nifti(hdr);
+  vol = niak_read_data_nifti(hdr);
+end
+if flag_zip
+  delete(file_tmp);
 end

--- a/commands/read_write/niak_read_vol.m
+++ b/commands/read_write/niak_read_vol.m
@@ -14,10 +14,10 @@ function [hdr,vol] = niak_read_vol(file_name)
 %    Supported formats are either NIFIT (*.nii,*.img/hdr), ANALYZE 
 %    (.img/.hdr/.mat) or MINC1/MINC2 (.mnc). Extra blanks are ignored. 
 %    File separator can be / or \ on Windows. Gzipped files (with an 
-%    additional .gz) are supported. Frames must be equally spaced in 
-%    time. For single file names, wild cards are supported (mutliple 
-%    files are treated in the same way as a matrix of image files 
-%    names).
+%    additional .gz) are supported using the gunzip system commad. 
+%    Frames must be equally spaced in time. For single file names, 
+%    wild cards are supported (mutliple files are treated in the same way 
+%    as a matrix of image files names).
 %
 % _________________________________________________________________________
 % OUTPUTS :
@@ -86,49 +86,56 @@ function [hdr,vol] = niak_read_vol(file_name)
 % SEE ALSO :
 % NIAK_READ_HDR_MINC, NIAK_WRITE_MINC, NIAK_WRITE_VOL, NIAK_READ_HDR_NIFTI,
 % NIAK_READ_NIFTI, NIAK_HDR_MAT2MINC, NIAK_HDR_MINC2MAT,
-% NIAK_COORD_VOX2WORLD, NIAK_COORD_WORLD2VOX.
+% NIAK_COORD_VOX2WORLD, NIAK_COORD_WORLD2VOX, NIAK_READ_DATA_NIFTI, 
+% NIAK_READ_DATA_MINC
 %
 % _________________________________________________________________________
 % COMMENTS
 %
 % NOTE 1:
-% If multiple files are specified, make sure all those files are in the
-% same space and are simple 3D volumes.
-% All data will be concatenated along the 4th dimension in the VOL array,
-% i.e. VOL(:,:,:,i) is the data of the ith file.
-% The HDR structure have multiple entries, each one corresponding to one
-% file.
+%   If multiple files are specified, make sure all those files are in the
+%   same space and are simple 3D volumes.
+%   All data will be concatenated along the 4th dimension in the VOL array,
+%   i.e. VOL(:,:,:,i) is the data of the ith file.
+%   The HDR structure have multiple entries, each one corresponding to one
+%   file.
 %
 % NOTE 2:
-% In order to read MINC files, a proper installation of minc tools is
-% required (see http://www.bic.mni.mcgill.ca/software/minc/).
+%   In order to read MINC files, a proper installation of minc tools is
+%   required (see http://www.bic.mni.mcgill.ca/software/minc/).
 %
 % NOTE 3:
-% The extension of zipped file is assumed to be .gz. The tools used to
-% unzip files in 'gunzip'. This setting can be changed by changing the
-% variables GB_NIAK_ZIP_EXT and GB_NIAK_UNZIP in the file NIAK_GB_VARS.
+%   The extension of zipped file is assumed to be .gz. The tools used to
+%   unzip files is 'gunzip'. 
 %
 % NOTE 4:
-% "voxel coordinates" start from 0. This is not the default matlab
-% behaviour, that indexes array starting from 1. To convert coordinates
-% from (matlab) voxel system to world system see NIAK_COORD_WORLD2VOX and
-% NIAK_COORD_VOX2WORLD.
+%   "voxel coordinates" start from 0. This is not the default matlab
+%   behaviour, that indexes array starting from 1. To convert coordinates
+%   from (matlab) voxel system to world system see NIAK_COORD_WORLD2VOX and
+%   NIAK_COORD_VOX2WORLD.
 %
 % NOTE 5:
-% If the name of the file is of the form toto.ext, the reader will look for 
-% a file toto_extra.mat. If such a file exist, it is assumed to contain matlab
-% variables and is loaded in HDR.EXTRA. This generic mechanism makes it easy to 
-% attach custom information to a file which may not be easy to achieve in a 
-% consistent way for all data formats. 
+%   If the name of the file is of the form toto.ext, the reader will look for 
+%   a file toto_extra.mat. If such a file exist, it is assumed to contain matlab
+%   variables and is loaded in HDR.EXTRA. This generic mechanism makes it easy to 
+%   attach custom information to a file. 
 %
-% Copyright (c) Pierre Bellec, Montreal Neurological Institute, 2008.
-% Centre de recherche de l'institut de Griatrie de Montral,
-% Dpartement d'informatique et de recherche oprationnelle,
-% Universit de Montral, 2010-2011.
-% Maintainer : pierre.bellec@criugm.qc.ca
+% _________________________________________________________________________
+% EXAMPLES
+%   To read the header and data array from a file:
+%     [hdr,vol] = niak_read_vol('my_file.nii.gz');
+%
+% See license in the code. 
+ 
+% Copyright (c) Pierre Bellec, 2008-2016.
+% Montreal Neurological Institute, 2008-2010
+% Centre de recherche de l'institut de geriatrie de Montreal, 
+% Department of Computer Science and Operations Research
+% University of Montreal, Qubec, Canada, 2010-2016
+% Maintainer: pierre.bellec@criugm.qc.ca
 % See licensing information in the code.
-% Keywords : medical imaging, I/O, reader, minc
-
+% Keywords: medical imaging, I/O, reader, minc, nifti
+%
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the "Software"), to deal
 % in the Software without restriction, including without limitation the rights
@@ -147,10 +154,11 @@ function [hdr,vol] = niak_read_vol(file_name)
 % OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 % THE SOFTWARE.
 
+flag_gb_niak_fast_gb = true;
 niak_gb_vars
   
 if ~ischar(file_name)
-    error('niak_read_vol: FILE_NAME should be a string or a matrix of strings')
+    error('niak_read_vol: FILE_NAME should be a structure, a string or a matrix of strings')
 end
 
 nb_file = size(file_name,1);
@@ -213,42 +221,10 @@ else
 
         %% The file exists
         file_name = niak_full_file(file_name);
-        [path_f,name_f,type] = fileparts(file_name);
+        [path_f,name_f,type] = niak_fileparts(file_name);
         switch type
-
-            case gb_niak_zip_ext
-
-                %% The file is zipped... Unzip it first and restart reading              
-
-                [path_f_tmp,name_f,type] = fileparts(name_f);
-                file_extra = [path_f filesep name_f '_extra.mat'];
-                file_tmp_gz = niak_file_tmp([name_f type gb_niak_zip_ext]);
                 
-                [succ,msg] = system(cat(2,'cp "',file_name,'" ',file_tmp_gz));
-                if succ~=0
-                    error(msg)
-                end
-                
-                instr_unzip = cat(2,gb_niak_unzip,' "',file_tmp_gz,'"');
-
-                [succ,msg] = system(instr_unzip);
-                if succ ~= 0
-                    error(cat(2,'niak:read: ',msg,'. There was a problem unzipping the file. Please check that the command ''',gb_niak_unzip,''' works, or change this command using the variable GB_NIAK_UNZIP in the file NIAK_GB_VARS'));
-                end
-
-                if nargout == 2
-                    [hdr,vol] = niak_read_vol(file_tmp_gz(1:end-length(gb_niak_zip_ext)));
-                else
-                    hdr = niak_read_vol(file_tmp_gz(1:end-length(gb_niak_zip_ext)));
-                end
-
-                delete(file_tmp_gz(1:end-length(gb_niak_zip_ext)));               
-                hdr.info.file_parent = file_name;
-                if psom_exist(file_extra)
-                    hdr.extra = load(file_extra);
-                end
-                
-            case {'.mnc'}
+            case {'.mnc','.mnc.gz'}
                 
                 %% This is either a minc1 or minc2 file
                 if nargout == 2
@@ -261,7 +237,7 @@ else
                     hdr.extra = load(file_extra);
                 end
                 
-            case {'.nii','.img'}
+            case {'.nii','.nii.gz','.img'}
                 
                 %% This is a nifti file (either one file .nii, or two files
                 %% .img/hdr
@@ -278,7 +254,7 @@ else
             otherwise
 
                 %% Unsupported extension
-                error('niak:read: Unknown file extension %s. Only .mnc, .nii and .img are supported.',type)
+                error('niak:read: Unknown file extension %s. Only .mnc(.gz), .nii(.gz) and .img are supported.',type)
         end
     end
 

--- a/commands/read_write/niak_unzip.m
+++ b/commands/read_write/niak_unzip.m
@@ -1,7 +1,7 @@
 function [file_tmp,flag_zip] = niak_unzip(file_name)
 % Unzip a zipped file 
 %
-% SYNTAX: [FILE_TMP,FLAG_ZIP] = NIAK_UNZIP(PATH_NAME)
+% SYNTAX: [FILE_TMP,FLAG_ZIP] = NIAK_UNZIP(FILE_NAME)
 %
 % FILE_NAME (string) the name to a zipped file.
 % FILE_TMP (string) the name of the unzipped file. 
@@ -54,9 +54,9 @@ if flag_zip
     
     [succ,msg] = system(instr_unzip);
     if succ ~= 0
-        error(cat(2,'niak:read: ',msg,'. There was a problem unzipping the file. Please check that the command ''',gb_niak_unzip,''' works, or change this command using the variable GB_NIAK_UNZIP in the file NIAK_GB_VARS'));
+        error(cat(2,'There was a problem unzipping the file using GUNZIP: ',msg));
     end
-    file_tmp = file_tmp(1:end-length('.gz'))
+    file_tmp = file_tmp(1:end-length('.gz'));
 else
     file_tmp = file_name;
 end  

--- a/commands/read_write/niak_unzip.m
+++ b/commands/read_write/niak_unzip.m
@@ -1,0 +1,62 @@
+function [file_tmp,flag_zip] = niak_unzip(file_name)
+% Unzip a zipped file 
+%
+% SYNTAX: [FILE_TMP,FLAG_ZIP] = NIAK_UNZIP(PATH_NAME)
+%
+% FILE_NAME (string) the name to a zipped file.
+% FILE_TMP (string) the name of the unzipped file. 
+% FLAG_ZIP (boolean) true if the file was indeed zipped. 
+%
+% If the file is zipped, a temporary unzipped file is created. 
+% If the file is not zipped, FILE_TMP is identical to FILE_NAME. 
+%           
+% See license in the code. 
+ 
+% Copyright (c) Pierre Bellec, 2016.
+% Centre de recherche de l'institut de geriatrie de Montreal, 
+% Department of Computer Science and Operations Research
+% University of Montreal, Qubec, Canada, 2016
+% Maintainer: pierre.bellec@criugm.qc.ca
+% See licensing information in the code.
+%
+% Permission is hereby granted, free of charge, to any person obtaining a copy
+% of this software and associated documentation files (the "Software"), to deal
+% in the Software without restriction, including without limitation the rights
+% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+% copies of the Software, and to permit persons to whom the Software is
+% furnished to do so, subject to the following conditions:
+%
+% The above copyright notice and this permission notice shall be included in
+% all copies or substantial portions of the Software.
+%
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+% THE SOFTWARE.
+
+[path_f,name_f,type] = fileparts(file_name);
+
+flag_zip = strcmp(type,'.gz');
+if flag_zip
+    %% The file is zipped... Unzip it first and start reading                  
+    [path_f_tmp,name_f,type] = fileparts(name_f);
+    file_tmp = niak_file_tmp([name_f type '.gz']);
+    
+    [succ,msg] = system(cat(2,'cp "',file_name,'" ',file_tmp));
+    if succ~=0
+        error(msg)
+    end
+    
+    instr_unzip = cat(2,'gunzip -f "',file_tmp,'"');
+    
+    [succ,msg] = system(instr_unzip);
+    if succ ~= 0
+        error(cat(2,'niak:read: ',msg,'. There was a problem unzipping the file. Please check that the command ''',gb_niak_unzip,''' works, or change this command using the variable GB_NIAK_UNZIP in the file NIAK_GB_VARS'));
+    end
+    file_tmp = file_tmp(1:end-length('.gz'))
+else
+    file_tmp = file_name;
+end  

--- a/commands/read_write/niak_write_nifti.m
+++ b/commands/read_write/niak_write_nifti.m
@@ -4,41 +4,37 @@ function [] = niak_write_nifti(hdr,vol)
 % SYNTAX: [] = NIAK_WRITE_NIFTI(HDR,VOL)
 %
 % INPUTS:
-% VOL           (3D or 4D array) a 3D or 3D+t dataset
-% HDR.FILE_NAME (string) the name of the file that will be written.
-% HDR.TYPE      (string, default 'nii') the output format (either 'nii' for 
-%               NIFTI-1 one file data, 'img' for a couple '*.img'/'*.hdr' in 
-%               NIFTI-1 format or 'analyze' for a '*.img'/'*.hdr'/'*.mat')
-% HDR.INFO      (structure) The subfields are optional, yet they give control 
+%   VOL           (3D or 4D array) a 3D or 3D+t dataset
+%   HDR.FILE_NAME (string) the name of the file that will be written.
+%   HDR.TYPE      (string, default 'nii') the output format (either 'nii' for 
+%     NIFTI-1 one file data, 'img' for a couple '*.img'/'*.hdr' in 
+%     NIFTI-1 format or 'analyze' for a '*.img'/'*.hdr'/'*.mat')
+%   HDR.INFO      (structure) The subfields are optional, yet they give control 
 %               on critical space information. See NIAK_WRITE_VOL for more info.
-% HDR.DETAILS   (structure) the fields are the standard list of a NIFTI header.
+%   HDR.DETAILS   (structure) the fields are the standard list of a NIFTI header.
 %
 % OUTPUTS:
-% The data called VOL is stored into a file called FILENAME written in
-% nifti format. In the case of ANALYZE 7.5 file format, a file '.MAT' will 
-% also be created with the affine transform.
+%   The data called VOL is stored into a file called FILENAME written in
+%   nifti format. In the case of ANALYZE 7.5 file format, a file '.MAT' will 
+%   also be created with the affine transform.
 % 
+% NOTE: the output file name can also have a '.gz' extension, in which case 
+%   The output file will be automatically compressed. 
+%
 % SEE ALSO:
-% NIAK_READ_HDR_NIFTI, NIAK_READ_NIFTI, NIAK_WRITE_VOL, NIAK_READ_VOL
+% NIAK_READ_HDR_NIFTI, NIAK_READ_NIFTI, NIAK_READ_DATA_NIFTI, 
+% NIAK_WRITE_VOL, NIAK_READ_VOL
 %
-% COMMENTS:
 % See licensing information in the code.
-% Maintainer : pierre.bellec@criugm.qc.ca
-% Keywords : medical imaging, I/O, writer, nifti
 
-%   Part of this file is copied and modified under GNU license from
-%   MRI_TOOLBOX developed by CNSP in Flinders University, Australia
-%
-%   Important parts of this code are copied and modified from a matlab
-%   toolbox by Jimmy Shen (pls@rotman-baycrest.on.ca), and reshared here 
-%   with agreement under a MIT license.  
-%   http://www.mathworks.com/matlabcentral/fileexchange/loadFile.do?objectId=
-%   8797&objectType=file
-%
-% Copyright (c) Pierre Bellec, Montreal Neurological Institute, 2008.
-% Centre de recherche de l'institut de griatrie de Montral, 
+% Copyright (c) Pierre Bellec, Jimmy Shen, 2008-2016.
+% Montreal Neurological Institute, 2008-2010
+% Centre de recherche de l'institut de geriatrie de Montreal, 
 % Department of Computer Science and Operations Research
-% University of Montreal, Qubec, Canada, 2010-2014
+% University of Montreal, Qubec, Canada, 2010-2016
+% Maintainer: pierre.bellec@criugm.qc.ca
+% See licensing information in the code.
+% Keywords: medical imaging, I/O, reader, nifti
 %
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the "Software"), to deal
@@ -101,8 +97,8 @@ end
 
 %% Updating information of the header
 hdr.info.precision = class(vol);
-precision = hdr.info.precision;
-
+hdr.details.scl_slope = 1;
+hdr.details.scl_inter = 0;
 hdr.info.dimensions = size(vol);
 
 if ~isfield(hdr.details,'dim')


### PR DESCRIPTION
This PR should fix issue #169 Although the added feature is minor, I have refactored a bit the reader/writer. There is now a separate function niak_read_data_minc to read the data array in a minc file, provided a header structure is available. Also the un(g)zipping of file is now handled by a generic function `niak_unzip`. The feature is available for both minc and nifti (`niak_read_data_nifti` and `niak_read_data_minc`), and the other functions (`niak_read_minc`, `niak_read_nifti`, `niak_read_vol`) now depend on these functions. 