### PR TITLE
fixes #206

### DIFF
--- a/commands/read_write/niak_write_vol.m
+++ b/commands/read_write/niak_write_vol.m
@@ -286,6 +286,25 @@ elseif ischar(file_name)
         else
             flag_zip = false;
         end
+        
+        %% Check if header dimensions match volume
+        switch type_f
+            case {'nii'} % currently only for niak
+                n_dims = length(size(vol));
+                if ~all(hdr.details.dim(2:n_dims+1)==size(vol))
+                    dims = ones(1,8);
+                    dims(1) = length(size(vol));
+                    dims(2:dims(1)+1) = size(vol);
+                    dims(end-1:end) = 0;
+                    hdr.details.dim = dims;
+                    
+                    if n_dims <= 4
+                        hdr.info.dimensions = ones(1,4);
+                        hdr.info.dimensions(1:n_dims) = size(vol);
+                    end
+                end
+        end
+        
         switch type_f
             case {'minc1','minc2'} % That's a minc file
                 niak_write_minc(hdr,vol);


### PR DESCRIPTION
dimensions of the volume now supersede the header dimensions - only for nifti files though

Tested with subtype pipeline and opened in mricron, mri_info and nibabel. Dimensions are accurately read.